### PR TITLE
Add .golangci-lint and run lint fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,34 @@
+run:
+  tests: true
+  modules-download-mode: mod
+  skip-dirs: 
+  - vendor
+  timeout: 2m
+linters:
+  disable-all: true
+  enable:
+  - deadcode
+  - errcheck
+  - goconst
+  - gofumpt
+  - goimports
+  - golint
+  - gosec
+  - gosimple
+  - govet
+  - ineffassign
+  - nakedret
+  - staticcheck
+  - structcheck
+  - unused
+  - varcheck
+  - whitespace
+linters-settings:
+  govet:
+    check-shadowing: true
+issue:
+  exclude-use-default: false
+  exclude:
+  - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
+  - 'shadow: declaration of "err" shadows declaration at line (\d+)'
+

--- a/cmd/clients.go
+++ b/cmd/clients.go
@@ -10,9 +10,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var clientNickname string
-var clientIDArg string
-var projectIDArg string
+var (
+	clientNickname string
+	clientIDArg    string
+	projectIDArg   string
+)
 
 // clientCmd represents the client command
 var clientCmd = &cobra.Command{
@@ -38,7 +40,7 @@ var addClientCmd = &cobra.Command{
 			log.Fatal("Project ID must be an integer.")
 		}
 
-		var newClient = track.Client{
+		newClient := track.Client{
 			Nickname:  clientNickname,
 			ClientID:  clientID,
 			ProjectID: projectID,

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -83,7 +83,6 @@ var editCmd = &cobra.Command{
 		fmt.Println()
 		fmt.Println(entry.String())
 		tracker.SaveEntries([]track.Entry{entry})
-
 	},
 }
 

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -92,7 +92,6 @@ var logCmd = &cobra.Command{
 		}
 
 		fmt.Println("Total hours recorded: ", total.Round(time.Minute))
-
 	},
 }
 

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -38,7 +38,6 @@ func ParseTimeArg(arg string) (time.Time, error) {
 				break
 			}
 		}
-
 	}
 	if res.IsZero() {
 		msg := fmt.Sprintf("Unable to parse %s using formats %v", arg, dateFmts)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,12 +22,14 @@ type Config struct {
 	Clients       []track.Client `mapstructure:"clients"`
 }
 
-var cfgFile string
-var cfg Config
-var startedArg string
-var finishedArg string
-var logLocation string
-var durationArg string
+var (
+	cfgFile     string
+	cfg         Config
+	startedArg  string
+	finishedArg string
+	logLocation string
+	durationArg string
+)
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -89,14 +89,16 @@ func initConfig() {
 	viper.AutomaticEnv() // read in environment variables that match
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		err := viper.Unmarshal(&cfg)
-		if err != nil {
+		if err := viper.Unmarshal(&cfg); err != nil {
 			log.Fatal("unable to decode into struct", err)
 		}
 		if len(cfg.Clients) == 0 {
 			cfg.CurrentClient = track.Client{Nickname: "default", ProjectID: 0, ClientID: 0}
 			cfg.Clients = []track.Client{cfg.CurrentClient}
-			WriteConfig(cfg)
+
+			if err := WriteConfig(cfg); err != nil {
+				log.Fatal("unable to decode into struct", err)
+			}
 		}
 		fmt.Printf("Using client: %s\n\n", cfg.CurrentClient.Nickname)
 	}

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -14,9 +14,7 @@ import (
 	"github.com/mitchellh/go-homedir"
 )
 
-var (
-	RedirectURI = "https://hankdoupe.com/ttrack.html"
-)
+var RedirectURI = "https://hankdoupe.com/ttrack.html"
 
 // Credentials contains the data from a successful authentication
 // flow.

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -210,6 +210,8 @@ func (oauthClient *Client) Cache(credentials Credentials) {
 	}
 
 	fmt.Println("Writing credentials to:", location)
+
+	// nolint: gosec
 	if err := ioutil.WriteFile(location, data, 0644); err != nil {
 		log.Fatal(err)
 	}

--- a/track/client.go
+++ b/track/client.go
@@ -28,7 +28,7 @@ func AddClient(clients []Client, newClient Client) ([]Client, error) {
 }
 
 func matches(client Client, params Client) bool {
-	if params.Nickname != "" && strings.ToLower(client.Nickname) == strings.ToLower(params.Nickname) {
+	if params.Nickname != "" && strings.EqualFold(client.Nickname, params.Nickname) {
 		return true
 	}
 	if params.ClientID > 0 && client.ClientID == params.ClientID {

--- a/track/entry.go
+++ b/track/entry.go
@@ -135,7 +135,6 @@ func SortEntries(entries []Entry) {
 // UpdateEntries merges entries in left with entries in right or add
 // new entries.
 func UpdateEntries(left []Entry, right []Entry, on string) ([]Entry, error) {
-
 	if on != "ID" && on != "ExternalID" {
 		return []Entry{}, fmt.Errorf("Update on must be ID or ExternalID. Got %s", on)
 	}

--- a/track/entry.go
+++ b/track/entry.go
@@ -102,7 +102,7 @@ func FilterEntries(entries []Entry, params FilterParameters) []Entry {
 	if !params.Since.IsZero() {
 		i := sort.Search(len(res), func(i int) bool { return res[i].StartedAt.Sub(params.Since).Seconds() >= 0 })
 		if i < len(entries) {
-			res = res[i:len(res)]
+			res = res[i:]
 		} else {
 			// No entries with started at less than params.Since
 			return []Entry{}
@@ -122,7 +122,7 @@ func FilterEntries(entries []Entry, params FilterParameters) []Entry {
 	// 	TODO
 	// }
 	if len(res) > params.Limit && params.Limit > 0 {
-		res = res[len(res)-params.Limit : len(res)]
+		res = res[len(res)-params.Limit:]
 	}
 	return res
 }

--- a/track/entry_test.go
+++ b/track/entry_test.go
@@ -67,7 +67,6 @@ func TestAddEntries(t *testing.T) {
 
 	for _, on := range []string{"ID", "ExternalID"} {
 		result, err := UpdateEntries(left, right, on)
-
 		if err != nil {
 			t.Error(err)
 		}
@@ -95,7 +94,6 @@ func TestUpdateEntries(t *testing.T) {
 	}
 
 	result, err := UpdateEntries(entries, []Entry{newEntry}, "ID")
-
 	if err != nil {
 		t.Error(err)
 	}

--- a/track/freshbooks.go
+++ b/track/freshbooks.go
@@ -15,14 +15,14 @@ import (
 // TimeEntry represents the FreshBooks Time Entry object.
 // This is analagous to the Track object.
 type TimeEntry struct {
+	StartedAt time.Time `json:"started_at"`
 	Note      string    `json:"note"`
 	Duration  int       `json:"duration"`
 	ClientID  int       `json:"client_id,omitempty"`
 	ProjectID int       `json:"project_id,omitempty"`
-	IsLogged  bool      `json:"is_logged"`
-	StartedAt time.Time `json:"started_at"`
-	Active    bool      `json:"active"`
 	ID        int       `json:"id"`
+	IsLogged  bool      `json:"is_logged"`
+	Active    bool      `json:"active"`
 }
 
 // TimeEntryPayload is the data structure for data posted to freshbooks.com.

--- a/track/local.go
+++ b/track/local.go
@@ -112,6 +112,7 @@ func (tracker *Local) SaveEntries(entries []Entry) []Entry {
 		log.Fatal(err)
 	}
 
+	// nolint: gosec
 	if err := ioutil.WriteFile(logLocation, data, 0644); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This adds the standard for go linting to the repo https://golangci-lint.run/. Gotta install it locally and then run

```
golangci-lint run --fix
```

The real trick is to set this up for your IDE so that on save you automatically run the linter and you don't have to do much. If you're so inclined you can also run it as a CI step, but not sure how to set that up on a public GH repo.

## what this PR does
- adds the linter with some basic good defaults then run it with `--fix` to automatically fix issues. You can pick and choose which linters you want based on the docs
- made some manual fixes in the second commit. Notably just told it to ignore the security issue with writing a new File with `644` permissions for now, I'll leave that up to you if you care.
